### PR TITLE
Add support for tfp policy id claims

### DIFF
--- a/WebApp-OpenIDConnect-DotNet/Controllers/AccountController.cs
+++ b/WebApp-OpenIDConnect-DotNet/Controllers/AccountController.cs
@@ -42,7 +42,13 @@ namespace WebApp_OpenIDConnect_DotNet.Controllers
         {
             if (HttpContext.User != null && HttpContext.User.Identity.IsAuthenticated)
             {
-                string scheme = (HttpContext.User.FindFirst("http://schemas.microsoft.com/claims/authnclassreference"))?.Value;
+                // try to find the tfp policy id claim (default)
+                var scheme = (HttpContext.User.FindFirst("tfp"))?.Value;
+
+                // fall back to legacy acr policy id claim
+                if (string.IsNullOrEmpty(scheme))
+                    scheme = (HttpContext.User.FindFirst("http://schemas.microsoft.com/claims/authnclassreference"))?.Value;
+
                 await HttpContext.Authentication.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
                 await HttpContext.Authentication.SignOutAsync(scheme.ToLower(), new AuthenticationProperties { RedirectUri = "/" });
             }


### PR DESCRIPTION
tfp policy id's are the default type, acr id's are supported for backwards compatibility.
[Azure Active Directory B2C: Token, session and single sign-on configuration](https://docs.microsoft.com/en-us/azure/active-directory-b2c/active-directory-b2c-token-session-sso)

I modified the code to attempt to find a tfp policy id first, and then search for an acr id of if the tfp policy is not found.  This should ease the pain of folks just learning to use AzureAD B2C.
