### PR TITLE
UseTokenLifetime true

### DIFF
--- a/WebApp-OpenIDConnect-DotNet/OpenIdConnectOptionsSetup.cs
+++ b/WebApp-OpenIDConnect-DotNet/OpenIdConnectOptionsSetup.cs
@@ -24,7 +24,7 @@ namespace WebApp_OpenIDConnect_DotNet
         {
             options.ClientId = AzureAdB2COptions.ClientId;
             options.Authority = AzureAdB2COptions.Authority;
-            
+            options.UseTokenLifetime = true;
             options.TokenValidationParameters = new TokenValidationParameters() { NameClaimType = "name" };
 
             options.Events = new OpenIdConnectEvents()


### PR DESCRIPTION
Unlike regular aspnet, [the default for UseTokenLifetime in aspnet core is false](https://github.com/aspnet/Security/issues/147).
For Azure AD B2C, this should set to true so that aspnet honors the [Token lifetime configuration](https://docs.microsoft.com/en-us/azure/active-directory-b2c/active-directory-b2c-token-session-sso#token-lifetimes-configuration) B2C admins configure in the portal.