### PR TITLE
Escaping error query string

### DIFF
--- a/WebApp-OpenIDConnect-DotNet/OpenIdConnectOptionsSetup.cs
+++ b/WebApp-OpenIDConnect-DotNet/OpenIdConnectOptionsSetup.cs
@@ -95,7 +95,7 @@ namespace WebApp_OpenIDConnect_DotNet
                 }
                 else
                 {
-                    context.Response.Redirect("/Home/Error?message=" + context.Failure.Message);
+                    context.Response.Redirect("/Home/Error?message=" + Uri.EscapeDataString(context.Failure.Message));
                 }
                 return Task.FromResult(0);
             }


### PR DESCRIPTION
Fix for: https://github.com/Azure-Samples/active-directory-b2c-dotnetcore-webapp/issues/70
- Escaping error query string, since it could contain special characters that will lead to an invalid URL.